### PR TITLE
feat(extension): Connect background script to LLM provider #24

### DIFF
--- a/apps/extension/panel/index.html
+++ b/apps/extension/panel/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Content Security Policy for secure communication -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self' http://localhost:11434 http://127.0.0.1:11434; style-src 'self' 'unsafe-inline'; script-src 'self';"
+    />
     <title>Briefcase</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>

--- a/apps/extension/src/background.js
+++ b/apps/extension/src/background.js
@@ -1,4 +1,197 @@
-/* global setTimeout */
+/* global setTimeout, clearTimeout, fetch, AbortController, TextDecoder */
+
+// TODO: Import from @briefcase/providers when bundling is set up
+// For now, defining OllamaProvider inline as a temporary solution
+const OllamaProvider = {
+  // Configuration - these would come from extension settings in production
+  OLLAMA_BASE_URL: "http://localhost:11434",
+  OLLAMA_MODEL: "llama3.2",
+  REQUEST_TIMEOUT_MS: 30000, // 30 seconds
+
+  /**
+   * Build a system prompt based on user parameters
+   */
+  buildSystemPrompt(params) {
+    const lengthMap = {
+      brief: "2-3 sentences",
+      medium: "1-2 paragraphs",
+      verbose: "3-4 paragraphs with comprehensive detail",
+    };
+
+    const levelMap = {
+      kinder: "a 5-year-old child (use very simple words and short sentences)",
+      high_school: "a high school student (clear and accessible language)",
+      college: "a college student (sophisticated but clear)",
+      phd: "an expert in the field (technical language acceptable)",
+    };
+
+    const styleMap = {
+      plain: "Write in plain, flowing paragraphs",
+      bullets: "Use bullet points for key information",
+      executive: "Format as an executive summary with clear sections",
+    };
+
+    const length = params?.length || "medium";
+    const level = params?.level || "college";
+    const style = params?.style || "bullets";
+
+    return `You are an expert content summarizer. Your task is to create a summary of the provided text.
+
+Requirements:
+- Length: ${lengthMap[length]}
+- Audience: Write for ${levelMap[level]}
+- Format: ${styleMap[style]}
+- Focus on the main ideas and key takeaways
+- Be accurate and faithful to the source material
+- Do not include any preamble like "Here is the summary" - start directly with the content`;
+  },
+
+  /**
+   * Summarize content using Ollama streaming API
+   */
+  async *summarize(content, params, _signal) {
+    const systemPrompt = this.buildSystemPrompt(params);
+    const userPrompt = `Please summarize the following content:\n\n${content}`;
+
+    // Prepare the request body
+    const requestBody = {
+      model: this.OLLAMA_MODEL,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      stream: true,
+      options: {
+        temperature: 0.7,
+        top_p: 0.9,
+      },
+    };
+
+    // Set up timeout handling
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.REQUEST_TIMEOUT_MS);
+
+    // Use timeout signal (AbortSignal.any() may not be available in all Chrome versions)
+    // For now, just use the timeout signal
+    const combinedSignal = controller.signal;
+
+    let response;
+
+    try {
+      // Make the request to Ollama
+      response = await fetch(`${this.OLLAMA_BASE_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+        signal: combinedSignal,
+      });
+
+      clearTimeout(timeoutId);
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (error.name === "AbortError") {
+        // Timeout occurred
+        throw new Error("Request timed out. Please try again.");
+      }
+
+      // Connection error - likely Ollama not running
+      if (error.message.includes("fetch")) {
+        throw new Error(
+          "Cannot connect to Ollama. Please ensure Ollama is running with 'ollama serve'",
+        );
+      }
+
+      throw new Error("Failed to connect to Ollama: " + error.message);
+    }
+
+    // Handle non-OK responses
+    if (!response.ok) {
+      const errorText = await response.text();
+
+      if (response.status === 404 && errorText.includes("model")) {
+        throw new Error(
+          `Model '${this.OLLAMA_MODEL}' not found. Please pull it with: ollama pull ${this.OLLAMA_MODEL}`,
+        );
+      }
+
+      throw new Error(`Ollama API error (${response.status}): ${errorText}`);
+    }
+
+    // Check for response body
+    if (!response.body) {
+      throw new Error("No response body from Ollama");
+    }
+
+    // Set up streaming response handling
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          // Process any remaining buffered content
+          if (buffer.trim()) {
+            try {
+              const parsed = JSON.parse(buffer);
+              if (parsed.message?.content) {
+                yield parsed.message.content;
+              }
+            } catch {
+              console.warn("[BG] Failed to parse final buffer:", buffer);
+            }
+          }
+          break;
+        }
+
+        // Decode the chunk and add to buffer
+        buffer += decoder.decode(value, { stream: true });
+
+        // Split by newlines to process complete JSON objects
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || ""; // Keep the last potentially incomplete line
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+
+          try {
+            const parsed = JSON.parse(line);
+
+            // Check if this is the end-of-stream marker
+            if (parsed.done === true) {
+              // Yield any final content
+              if (parsed.message?.content) {
+                yield parsed.message.content;
+              }
+              return;
+            }
+
+            // Yield the content chunk
+            if (parsed.message?.content) {
+              yield parsed.message.content;
+            }
+          } catch (parseError) {
+            console.error("[BG] Failed to parse NDJSON line:", line, parseError);
+            // Continue processing other lines
+          }
+        }
+      }
+    } catch (error) {
+      if (error.name === "AbortError") {
+        console.log("[BG] Stream reading aborted");
+        return;
+      }
+
+      console.error("[BG] Error reading stream:", error);
+      throw new Error("Failed to process streaming response from Ollama");
+    } finally {
+      reader.releaseLock();
+    }
+  },
+};
 
 // Handle action button click to open side panel
 chrome.action.onClicked.addListener(async (tab) => {
@@ -106,12 +299,68 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           console.log("[BG] - Error:", contentResult.error.code, "-", contentResult.error.message);
         }
 
-        // TODO: Process the content with LLM provider using msg.params and contentResult.payload
-        // For now, return a placeholder summary with the extracted content for testing
-        sendResponse({
-          text: "• Key point 1\n• Key point 2\n\nTL;DR: This is a placeholder summary.",
-          extractedPayload: contentResult?.payload || null,
-        });
+        // Process the content with LLM provider if we have valid content
+        if (contentResult?.payload && contentResult.payload.rawText) {
+          console.log("[BG] Starting LLM summarization with OllamaProvider");
+          console.log("[BG] - Parameters:", msg.params);
+
+          try {
+            // Call OllamaProvider.summarize with extracted content and parameters
+            const summaryGenerator = OllamaProvider.summarize(
+              contentResult.payload.rawText,
+              msg.params,
+            );
+
+            // Iterate over the summary stream and accumulate chunks
+            let fullSummary = "";
+            let chunkCount = 0;
+
+            console.log("[BG] Starting to receive summary chunks...");
+            for await (const chunk of summaryGenerator) {
+              chunkCount++;
+              fullSummary += chunk;
+              // Log each chunk as it arrives for validation
+              console.log(`[BG] Received chunk #${chunkCount}: "${chunk.substring(0, 50)}..."`);
+            }
+
+            console.log(`[BG] Summary complete. Total chunks received: ${chunkCount}`);
+            console.log(`[BG] Summary length: ${fullSummary.length} characters`);
+
+            // Send the complete summary
+            sendResponse({
+              text: fullSummary,
+              extractedPayload: contentResult.payload,
+              metadata: {
+                chunksReceived: chunkCount,
+                provider: "ollama",
+                model: OllamaProvider.OLLAMA_MODEL,
+              },
+            });
+          } catch (llmError) {
+            console.error("[BG] LLM summarization failed:", llmError);
+
+            // Send error response with fallback to original content
+            sendResponse({
+              error: {
+                code: "LLM_SUMMARIZATION_FAILED",
+                message: llmError.message || "Failed to generate summary",
+                details: "The LLM provider encountered an error during summarization",
+              },
+              extractedPayload: contentResult.payload,
+              fallbackText: "Unable to generate summary. Original content available.",
+            });
+          }
+        } else {
+          console.warn("[BG] No valid content to summarize");
+          sendResponse({
+            error: {
+              code: "NO_CONTENT_TO_SUMMARIZE",
+              message: "No extracted content available for summarization",
+              details: "The content extraction may have failed or returned empty",
+            },
+            extractedPayload: contentResult?.payload || null,
+          });
+        }
       } catch (error) {
         console.error("[BG] Error handling SUMMARIZE message:", error);
         sendResponse({


### PR DESCRIPTION
## Summary
This PR implements the connection between the background script and LLM provider to process extracted content with Ollama, as described in issue #24.

## Changes
- ✅ Added inline OllamaProvider implementation in `background.js`
  - Temporary solution until bundling is properly configured
  - Follows the same pattern as the inline extractFromDom in contentScript.js
  
- ✅ Integrated LLM summarization in the SUMMARIZE message handler
  - Calls `OllamaProvider.summarize` with extracted content
  - Passes user parameters (length, level, style) to the provider
  - Uses `for await...of` to iterate over the async stream
  
- ✅ Added comprehensive stream processing
  - Accumulates summary chunks into complete text
  - Logs each chunk as it arrives (validation requirement met)
  - Tracks chunk count and summary metrics

## Implementation Details

### OllamaProvider Integration
The provider includes:
- System prompt building based on user parameters (brief/medium/verbose, kinder/high_school/college/phd, plain/bullets/executive)
- Streaming response handling with NDJSON parsing
- Timeout protection (30 seconds)
- Error handling for connection issues, missing models, and API errors

### Message Flow
1. SUMMARIZE message received with params
2. Content extracted from page (from #23)
3. If content available, call OllamaProvider.summarize
4. Iterate over streaming chunks with for-await-of
5. Log each chunk to console
6. Return complete summary with metadata

### Validation
✅ **Console logging implemented** - Each chunk is logged as it arrives:
```javascript
console.log(\`[BG] Received chunk #\${chunkCount}: "\${chunk.substring(0, 50)}..."\`);
```

## Error Handling
- Connection errors (Ollama not running)
- Model not found errors
- Timeout handling
- Graceful fallback when no content available

## Testing Instructions
1. Ensure Ollama is running locally: `ollama serve`
2. Pull the required model: `ollama pull llama3.2`
3. Load the extension in Chrome
4. Navigate to any content-rich webpage
5. Click the extension icon to open side panel
6. Trigger summarization
7. Check console logs for:
   - "[BG] Starting LLM summarization with OllamaProvider"
   - "[BG] Received chunk #1: ..."
   - "[BG] Summary complete. Total chunks received: X"

## Notes
- The OllamaProvider is inlined temporarily (similar to extractFromDom approach)
- Will be replaced with proper import once bundling is configured
- Host permissions already in place via `<all_urls>` in manifest

## Dependencies
- Depends on #23 (content extraction) - ✅ Already merged

Closes #24